### PR TITLE
fixed overly strict library constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "mikehaertl/php-shellcommand": "1.2.0"
+        "mikehaertl/php-shellcommand": "^1.2.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
I think it's fine to use `1.*`, `>= 1.2` for the shell-command extension.
